### PR TITLE
Add avconv fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,25 @@
 "use strict";
 
 var spawn = require("child_process").spawn,
-	ffmpeg = spawn.bind(null, "ffmpeg"),
+	ffmpeg = choosePlayer(),
 	fs = require("fs"),
 	through = require("through"),
 	concat = require("concat-stream");
+
+function choosePlayer(){
+	var choices = ["avconv", "ffmpeg"];
+
+	while(choices.length > 0){
+		var choice = choices.shift();
+		var proc = spawn.spawnSync(choice);
+
+		if(!proc.error){
+			return spawn.bind(null, choice);
+		}
+	}
+
+	throw new Error("Please install ffmpeg/avconv and add it to the path!");
+}
 
 module.exports.read = function(src, options, callback) {
 	if (typeof options === "function") {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var spawn = require("child_process").spawn,
+	spawnSync = require("child_process").spawnSync,
 	ffmpeg = choosePlayer(),
 	fs = require("fs"),
 	through = require("through"),
@@ -12,7 +13,7 @@ function choosePlayer(){
 
 	while(choices.length > 0){
 		var choice = choices.shift();
-		var proc = spawn.spawnSync(choice);
+		var proc = spawnSync(choice);
 
 		if(!proc.error){
 			return spawn.bind(null, choice);
@@ -20,6 +21,7 @@ function choosePlayer(){
 	}
 
 	throw new Error("Please install ffmpeg/avconv and add it to the path!");
+	return null;
 }
 
 module.exports.read = function(src, options, callback) {


### PR DESCRIPTION
On ubuntu, libavtools is available and works the same as ffmpeg. This PR will first try to use ffmpeg if available, and if not will use avconv. It doesn't change the functionality of the module at all, just allows it to be used on more platforms.