### PR TITLE
Fix: allow ffmpeg executable to be set through environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 "use strict";
 
 var spawn = require("child_process").spawn,
-	ffmpeg = spawn.bind(null, "ffmpeg"),
+	ffmpeg = spawn.bind(null, process.env.FFMPEG_PATH || "ffmpeg"),
 	fs = require("fs"),
 	through = require("through"),
 	concat = require("concat-stream");


### PR DESCRIPTION
This is the same format that https://github.com/parshap/node-ffmetadata uses for the FFMPEG environment variable.

Can you also please version bump this and publish it to npm?

My use case for this is that I use your library in my [Node.js based music player](https://github.com/benkaiser/node-music-player) and I am going to be publishing binary versions for windows, which would require this library to have this fix (as I'm shipping the ffmpeg binaries with the windows versions).

Thanks for the awesome library btw!